### PR TITLE
ci: run on main branch instead of master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   ci:


### PR DESCRIPTION
The repository default branch is `main`, but the CI workflow only triggered on `master` (push and pull_request).
As a result CI never ran on pushes or PRs to `main`.

This switches the triggers to `main` so CI actually runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)