### PR TITLE
docs: fix outdated bs-dependencies key in installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install re-color-contrast
 Then add `re-color-contrast` as a dependency to `rescript.json`:
 
 ```diff
-"bs-dependencies": [
+"dependencies": [
 +  "re-color-contrast"
 ]
 ```


### PR DESCRIPTION
## Summary

- Replace legacy BuckleScript `bs-dependencies` key with the current ReScript `dependencies` key in the Getting Started snippet

The rest of the README, `rescript.json`, `package.json`, and CI workflow are all accurate and up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)